### PR TITLE
Add article edit form

### DIFF
--- a/darkagesWiki/__init__.py
+++ b/darkagesWiki/__init__.py
@@ -1,0 +1,3 @@
+"""Django project package."""
+
+# ruff: noqa: N999

--- a/wiki/admin.py
+++ b/wiki/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -1,6 +1,6 @@
 import django.forms
 from django.forms import ModelForm
-from wiki.models import Weapon, Item
+from wiki.models import Article, Weapon, Item
 
 
 class NewWeaponForm(ModelForm):
@@ -15,3 +15,10 @@ class NewItemForm(ModelForm):
         fields = django.forms.ALL_FIELDS
 
 
+class ArticleForm(ModelForm):
+    """Create or edit an ``Article`` instance."""
+
+    class Meta(object):
+        model = Article
+        # only expose editable fields
+        fields = ["name", "published"]

--- a/wiki/tests.py
+++ b/wiki/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -25,4 +25,6 @@ urlpatterns = [
     path('new/quest/', views.new_quest, name='new-quest'),
     path('new/knowledge/', views.new_knowledge, name='new-knowledge'),
     path('new/item/', views.new_item, name='new-item'),
+    path('article/new/', views.article_form, name='article-new'),
+    path('article/edit/<int:pk>/', views.article_form, name='article-edit'),
 ]

--- a/wiki/views.py
+++ b/wiki/views.py
@@ -1,9 +1,10 @@
 from django.conf import settings
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
 
 from . import forms
 from .functions import base_context
-from .models import Weapon, Armor, Equipment
+from .models import Article, Weapon, Armor, Equipment
 
 
 def index(request):
@@ -123,3 +124,24 @@ def new_item(request):
 
 def new_quest(request):
     return None
+
+
+@login_required
+def article_form(request, pk=None):
+    article = get_object_or_404(Article, pk=pk) if pk else None
+    if request.method == "POST":
+        form = forms.ArticleForm(request.POST, instance=article)
+        if form.is_valid():
+            article = form.save(commit=False)
+            if not article.pk:
+                article.author = request.user
+            article.save()
+            return redirect("index")
+    else:
+        form = forms.ArticleForm(instance=article)
+
+    context = {
+        "title": "Edit Article" if pk else "New Article",
+        "form": form,
+    }
+    return render(request, "editors/new_article.html", base_context(context))


### PR DESCRIPTION
## Summary
- add `ArticleForm` for editing Article objects
- create `article_form` view for creation/editing of articles
- expose new view via URL patterns
- silence Ruff violation from module name

## Testing
- `ruff check .`
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68436445c90c83279341f5814b5f2657